### PR TITLE
Fix for the user-selected configurations not being checked in the viewer

### DIFF
--- a/org.apache.ivyde.eclipse/src/java/org/apache/ivyde/internal/eclipse/cpcontainer/IvydeContainerPage.java
+++ b/org.apache.ivyde.eclipse/src/java/org/apache/ivyde/internal/eclipse/cpcontainer/IvydeContainerPage.java
@@ -383,9 +383,9 @@ public class IvydeContainerPage extends NewElementWizardPage implements IClasspa
 
     private void loadFromConf() {
         ivyFilePathText.init(conf.getIvyXmlPath());
-        confTableViewer.init(conf.getConfs());
 
         settingsSetupTab.init(conf.isSettingsProjectSpecific(), conf.getIvySettingsSetup());
+        confTableViewer.init(conf.getConfs()); // *after* settingsSetupTab.init()!
         classpathSetupTab.init(conf.isClassthProjectSpecific(), conf.getClasspathSetup());
         mappingSetupTab.init(conf.isMappingProjectSpecific(), conf.getMappingSetup());
         // project == null <==> container in a launch config: always resolve before launch


### PR DESCRIPTION
When you have an ivy.xml that extends another module and that other
module defines some configurations, it occurred that calling

  settingsSetupTab.init(conf.isSettingsProjectSpecific(),
conf.getIvySettingsSetup());

would cause the configurations being set again, because the
ModifyListener of ivyUserDirEditor would fire and cause
reinitialization.
