### PR TITLE
Fix IVYDE-386

### DIFF
--- a/org.apache.ivyde.eclipse/src/java/org/apache/ivyde/internal/eclipse/ui/menu/IvyMenuContributionItem.java
+++ b/org.apache.ivyde.eclipse/src/java/org/apache/ivyde/internal/eclipse/ui/menu/IvyMenuContributionItem.java
@@ -192,7 +192,7 @@ public class IvyMenuContributionItem extends CompoundContributionItem implements
             IContributionItem commandContributionItem) {
         if (menuManager != null) {
             menuManager.add(commandContributionItem);
-        } else {
+        } else if (commandContributionItem instanceof MenuManager) {
             items.add((MenuManager) commandContributionItem);
         }
     }


### PR DESCRIPTION
According to Eclipse documentation, IContributionItem can, in no way, be relied on to be a MenuManager and in Eclipse Oxygen, this code is causing an exception as documented in IVYDE-386, by myself.  Adding this check will resolve the Exception, which is causing menu building to fail for not only Ivy, but for other plugins as well.

The circumstances around why this is occurring are unknown to myself.

https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fui%2Fmenus%2FCommandContributionItem.html
https://issues.apache.org/jira/browse/IVYDE-386