### PR TITLE
Ivy 2.5.0 is available; Maven Central requires HTTPS

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -26,7 +26,7 @@ eclipse.consoleLog=false
 ignore.checkstyle=
 
 # Ivy version to use to build this project
-ivy.version=2.5.0-rc1
+ivy.version=2.5.0
 
 # URL of the mirror to use when trying to install Ivy from an official release
 mirror.url=http://archive.apache.org/dist/

--- a/build.xml
+++ b/build.xml
@@ -50,7 +50,7 @@
     <property name="rat.dir" value="${work.dir}/rat"/>
 
     <target name="download-ivy" unless="ivy.jar.file">
-        <property name="ivy.jar.url"  value="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar"/>
+        <property name="ivy.jar.url"  value="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar"/>
         <property name="ivy.jar.dir"  value="${work.dir}"/>
         <property name="ivy.jar.file" value="${ivy.jar.dir}/ivy.jar"/>
         <mkdir dir="${ivy.jar.dir}"/>

--- a/doc/src/sample/webapp-js-repo/webapp/ivysettings.xml
+++ b/doc/src/sample/webapp-js-repo/webapp/ivysettings.xml
@@ -20,7 +20,7 @@
     <settings defaultResolver="chain" />
 
     <resolvers>
-        <ibiblio name="maven-central" root="http://repo1.maven.org/maven2/" m2compatible="true" checksums="" />
+        <ibiblio name="maven-central" root="https://repo1.maven.org/maven2/" m2compatible="true" checksums="" />
         
         <filesystem name="local-js">
             <ivy pattern="${ivy.settings.dir}/../repo/[organisation]/[module]/[revision]/ivy.xml" />


### PR DESCRIPTION
Let's start building IvyDE again